### PR TITLE
Woodland workaround

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # forestTIME (development version)
 
+- A temporary workaround was implmented to deal with missing code for calculating biomass and carbon for woodland species (#163). Eventually, we will modify `fia_estimate()` to be able to produce carbon and biomass estimates for woodland species and this can be reverted to avoid confusion.
+  - `fia_tidy()` now keeps the `CARBON_AG` and `DRYBIO_AG` columns
+  - `interpolate_data()` (and therefore `fia_annualize()`) now linearly interpolates `CARBON_AG` and `DRYBIO_AG`
+  - `fia_estimate()` now overwrites `CARBON_AG` and `DRYBIO_AG` columns in the input unless the result of carbon estimation is `NA` (as is the case with woodland species and the occasional model fit error from the carbon estimation code)
 - The calculation of the `EXPNS` column no longer occurs as part of `interpolate_data()`.
 - Added a utility function, `fia_calc_expns()` to calculate and add an `EXPNS` column.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 - A temporary workaround was implmented to deal with missing code for calculating biomass and carbon for woodland species (#163). Eventually, we will modify `fia_estimate()` to be able to produce carbon and biomass estimates for woodland species and this can be reverted to avoid confusion.
   - `fia_tidy()` now keeps the `CARBON_AG` and `DRYBIO_AG` columns
   - `interpolate_data()` (and therefore `fia_annualize()`) now linearly interpolates `CARBON_AG` and `DRYBIO_AG`
-  - `fia_estimate()` now overwrites `CARBON_AG` and `DRYBIO_AG` columns in the input unless the result of carbon estimation is `NA` (as is the case with woodland species and the occasional model fit error from the carbon estimation code)
+  - `fia_estimate()` now overwrites `CARBON_AG` and `DRYBIO_AG` columns in the input unless the result of carbon estimation is `NA` (as is the case with woodland species).
 - The calculation of the `EXPNS` column no longer occurs as part of `interpolate_data()`.
 - Added a utility function, `fia_calc_expns()` to calculate and add an `EXPNS` column.
 

--- a/R/adjust_mortality.R
+++ b/R/adjust_mortality.R
@@ -50,7 +50,7 @@ adjust_mortality <- function(data_interpolated, use_mortyr = TRUE) {
     df <- data_interpolated |>
       dplyr::group_by(tree_ID) |>
       dplyr::mutate(
-        MORTYR_eff = if_else(
+        MORTYR_eff = dplyr::if_else(
           YEAR == MORTYR & STATUSCD == 1,
           MORTYR + 1,
           MORTYR

--- a/R/estimate_carbon.R
+++ b/R/estimate_carbon.R
@@ -3,7 +3,7 @@
 #' Estimates carbon using code provided by David Walker with slight
 #' modifications
 #'
-#' @param data_prepped tibble produced by [prep_carbon()]. 
+#' @param data_prepped tibble produced by [prep_carbon()].
 #' @author David Walker
 #' @noRd
 #' @returns a tibble
@@ -17,7 +17,7 @@ estimate_carbon <- function(data_prepped) {
     # Can't estimate carbon for trees with missing heights or woodland species woodland species
     dplyr::filter(JENKINS_SPGRPCD < 10, !is.na(HT)) |>
     # Can't estimate carbon for empty plots
-    dplyr::filter(!is.na(tree_ID) | !stringr::str_starts(tree_ID, "NA_")) |> 
+    dplyr::filter(!is.na(tree_ID) | !stringr::str_starts(tree_ID, "NA_")) |>
     dplyr::left_join(
       med_cr_prop |> dplyr::select(PROVINCE = Province, SFTWD_HRDWD, CRmn),
       by = dplyr::join_by(SFTWD_HRDWD, PROVINCE)
@@ -43,7 +43,10 @@ estimate_carbon <- function(data_prepped) {
 
   # original code doesn't work with NAs for STATUSCD as is the case with plots with no trees
   # fiadb[is.na(fiadb$CR) & fiadb$STATUSCD == 1, 'CR'] <- 0
-  fiadb <- dplyr::mutate(fiadb, CR = dplyr::if_else(is.na(CR) & STATUSCD == 1, 0, CR))
+  fiadb <- dplyr::mutate(
+    fiadb,
+    CR = dplyr::if_else(is.na(CR) & STATUSCD == 1, 0, CR)
+  )
 
   # planted loblolly/slash use separate equations
   fiadb[is.na(fiadb$STDORGCD), "STDORGCD"] <- 0
@@ -100,18 +103,38 @@ estimate_carbon <- function(data_prepped) {
         "DRYBIO_AG" = "BIOMASS", #Does not include foliage
         "DRIBIO_FOLIAGE" = "FOLIAGE", #just foliage
         "CARBON_AG" = "CARBON",
-        
+
         #total stem volumes
         "VOLTSGRS" = "VTOTIB_GROSS",
-        "VOLTSSND" = "VTOTIB_SOUND"#,
-        
+        "VOLTSSND" = "VTOTIB_SOUND" #,
+
         #bole volumes
-        # "VOLCFNET" = 
+        # "VOLCFNET" =
         # "VOLCFGRS" =
-        # "VOLCFSND" = 
+        # "VOLCFSND" =
       ))
     )
 
   #return
-  dplyr::left_join(data_prepped, fiadb2, by = dplyr::join_by(plot_ID, tree_ID, YEAR))
+  dplyr::left_join(
+    data_prepped, # input
+    fiadb2, # carbon estimates
+    by = dplyr::join_by(plot_ID, tree_ID, YEAR),
+    suffix = c("_interpolated", "_recalculated") # TODO: temporary
+  ) |>
+    # This is a temporary workaround for estimating carbon of woodland species
+    # through interpolation rather than re-calculating.  The `coalesce()` fills
+    # in any NAs for the re-calculated values with interpolated values
+    # TODO: eventually remove this
+    dplyr::mutate(
+      DRYBIO_AG = dplyr::coalesce(
+        DRYBIO_AG_recalculated,
+        DRYBIO_AG_interpolated
+      ),
+      CARBON_AG = dplyr::coalesce(
+        CARBON_AG_recalculated,
+        DRYBIO_AG_interpolated
+      ),
+      .keep = "unused"
+    )
 }

--- a/R/fia_tidy.R
+++ b/R/fia_tidy.R
@@ -76,7 +76,12 @@ fia_tidy <- function(db) {
       HT,
       ACTUALHT,
       CULL,
-      SPCD
+      SPCD,
+      # Temporary workaround for woodland species is to linearly interpolate
+      # carbon and biomass rather than re-calculated it.
+      # TODO: Eventually remove these columns to avoid confusing users.
+      CARBON_AG,
+      DRYBIO_AG
     )
 
   # Join the tables

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -39,8 +39,11 @@ interpolate_data <- function(data_expanded) {
     "DIA",
     "HT",
     "CULL",
-    "CR" #,
-    #  "CONDPROP_UNADJ" #this gets interpolated separately
+    "CR",
+    # Temporary workaround to get carbon estimates for woodland species
+    # TODO: eventually remove these
+    "CARBON_AG",
+    "DRYBIO_AG"
   )
   #variables that switch at the midpoint (rounded down) between surveys
   cols_midpt_switch <- c(


### PR DESCRIPTION
Addresses #163 with a temporary workaround.  

- `fia_tidy()` now keeps the `CARBON_AG` and `DRYBIO_AG` columns
- `interpolate_data()` (and therefore `fia_annualize()`) now linearly interpolates `CARBON_AG` and `DRYBIO_AG`
- `fia_estimate()` now overwrites `CARBON_AG` and `DRYBIO_AG` columns in the input unless the result of carbon estimation is `NA` (as is the case with woodland species).